### PR TITLE
Add test files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,8 @@
 test
 coverage
 .idea
+yarn.lock
+.yaspellerrc
+.travis.yml
+.eslintrc
+.editorconfig


### PR DESCRIPTION
A lot of people complain about `node_modules` size. So it will be good to take care and clean npm package from unnecessary test files.

@JLHwung You can check npm package content by calling `npm pack` command and open generated `.tgz` file.